### PR TITLE
Fix nodejs global usage in Remix v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm install --save remix-aws
 import * as build from '@remix-run/dev/server-build'
 import {AWSProxy, createRequestHandler} from 'remix-aws'
 
+// Required in Remix v2
+import { installGlobals } from '@remix-run/node'
+installGlobals()
+
 export const handler = createRequestHandler({
     build,
     mode: process.env.NODE_ENV,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/aws-lambda": "^8.10.125"
       },
       "devDependencies": {
-        "@types/node": "^18.0.4",
+        "@types/node": "^18.18.7",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
@@ -227,10 +227,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
-      "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA==",
-      "dev": true
+      "version": "18.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.7.tgz",
+      "integrity": "sha512-bw+lEsxis6eqJYW8Ql6+yTqkE6RuFtsQPSe5JxXbqYRFQEER5aJA9a5UH9igqDWm3X4iLHIKOHlnAXLM4mi7uQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.6",
@@ -2875,6 +2878,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/aws-lambda": "^8.10.125"
   },
   "devDependencies": {
-    "@types/node": "^18.0.4",
+    "@types/node": "^18.18.7",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",

--- a/src/adapters/api-gateway-v1.ts
+++ b/src/adapters/api-gateway-v1.ts
@@ -3,22 +3,15 @@ import type {
   APIGatewayProxyEventHeaders,
   APIGatewayProxyResult
 } from 'aws-lambda'
-import type {
-  Response as NodeResponse,
-} from '@remix-run/node'
 
-import {
-  Headers as NodeHeaders,
-  readableStreamToString,
-  Request as NodeRequest
-} from '@remix-run/node'
+import { readableStreamToString } from '@remix-run/node'
 import { URLSearchParams } from 'url'
 
 import { isBinaryType } from '../binaryTypes'
 
 import { RemixAdapter } from './index'
 
-function createRemixRequest(event: APIGatewayProxyEvent): NodeRequest {
+function createRemixRequest(event: APIGatewayProxyEvent): Request {
   const host = event.headers['x-forwarded-host'] || event.headers.Host
   const scheme = event.headers['x-forwarded-proto'] || 'http'
 
@@ -30,7 +23,7 @@ function createRemixRequest(event: APIGatewayProxyEvent): NodeRequest {
     'multipart/form-data'
   )
 
-  return new NodeRequest(url.href, {
+  return new Request(url.href, {
     method: event.requestContext.httpMethod,
     headers: createRemixHeaders(event.headers),
     body:
@@ -44,8 +37,8 @@ function createRemixRequest(event: APIGatewayProxyEvent): NodeRequest {
 
 function createRemixHeaders(
   requestHeaders: APIGatewayProxyEventHeaders
-): NodeHeaders {
-  const headers = new NodeHeaders()
+): Headers {
+  const headers = new Headers()
 
   for (const [header, value] of Object.entries(requestHeaders)) {
     if (value) {
@@ -57,7 +50,7 @@ function createRemixHeaders(
 }
 
 async function sendRemixResponse(
-  nodeResponse: NodeResponse
+  nodeResponse: Response
 ): Promise<APIGatewayProxyResult> {
   const contentType = nodeResponse.headers.get('Content-Type')
   const isBase64Encoded = isBinaryType(contentType)

--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -3,21 +3,14 @@ import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyStructuredResultV2
 } from 'aws-lambda'
-import type {
-  Response as NodeResponse,
-} from '@remix-run/node'
 
-import {
-  Headers as NodeHeaders,
-  readableStreamToString,
-  Request as NodeRequest
-} from '@remix-run/node'
+import { readableStreamToString } from '@remix-run/node'
 
 import { isBinaryType } from '../binaryTypes'
 
 import { RemixAdapter } from './index'
 
-function createRemixRequest(event: APIGatewayProxyEventV2): NodeRequest {
+function createRemixRequest(event: APIGatewayProxyEventV2): Request {
   const host = event.headers['x-forwarded-host'] || event.headers.host
   const search = event.rawQueryString.length ? `?${event.rawQueryString}` : ''
   const scheme = event.headers['x-forwarded-proto'] || 'http'
@@ -27,7 +20,7 @@ function createRemixRequest(event: APIGatewayProxyEventV2): NodeRequest {
     'multipart/form-data'
   )
 
-  return new NodeRequest(url.href, {
+  return new Request(url.href, {
     method: event.requestContext.http.method,
     headers: createRemixHeaders(event.headers, event.cookies),
     body:
@@ -42,8 +35,8 @@ function createRemixRequest(event: APIGatewayProxyEventV2): NodeRequest {
 function createRemixHeaders(
   requestHeaders: APIGatewayProxyEventHeaders,
   requestCookies?: string[]
-): NodeHeaders {
-  const headers = new NodeHeaders()
+): Headers {
+  const headers = new Headers()
 
   for (const [header, value] of Object.entries(requestHeaders)) {
     if (value) {
@@ -59,7 +52,7 @@ function createRemixHeaders(
 }
 
 async function sendRemixResponse(
-  nodeResponse: NodeResponse
+  nodeResponse: Response
 ): Promise<APIGatewayProxyStructuredResultV2> {
   const cookies: string[] = []
 

--- a/src/adapters/application-load-balancer.ts
+++ b/src/adapters/application-load-balancer.ts
@@ -3,22 +3,15 @@ import type {
   ALBEventHeaders,
   ALBResult
 } from 'aws-lambda'
-import type {
-  Response as NodeResponse,
-} from '@remix-run/node'
 
-import {
-  Headers as NodeHeaders,
-  readableStreamToString,
-  Request as NodeRequest
-} from '@remix-run/node'
+import { readableStreamToString } from '@remix-run/node'
 import { URLSearchParams } from 'url'
 
 import { isBinaryType } from '../binaryTypes'
 
 import { RemixAdapter } from './index'
 
-function createRemixRequest(event: ALBEvent): NodeRequest {
+function createRemixRequest(event: ALBEvent): Request {
   const headers = event?.headers || {}
   const host = headers['x-forwarded-host'] || headers.Host
   const scheme = headers['x-forwarded-proto'] || 'http'
@@ -31,7 +24,7 @@ function createRemixRequest(event: ALBEvent): NodeRequest {
     'multipart/form-data'
   )
 
-  return new NodeRequest(url.href, {
+  return new Request(url.href, {
     method: event.httpMethod,
     headers: createRemixHeaders(headers),
     body:
@@ -45,8 +38,8 @@ function createRemixRequest(event: ALBEvent): NodeRequest {
 
 function createRemixHeaders(
   requestHeaders: ALBEventHeaders
-): NodeHeaders {
-  const headers = new NodeHeaders()
+): Headers {
+  const headers = new Headers()
 
   for (const [header, value] of Object.entries(requestHeaders)) {
     if (value) {
@@ -58,7 +51,7 @@ function createRemixHeaders(
 }
 
 async function sendRemixResponse(
-  nodeResponse: NodeResponse
+  nodeResponse: Response
 ): Promise<ALBResult> {
   const contentType = nodeResponse.headers.get('Content-Type')
   const isBase64Encoded = isBinaryType(contentType)

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -9,10 +9,6 @@ import type {
 import type { ApiGatewayV1Adapter } from './api-gateway-v1'
 import type { ApiGatewayV2Adapter } from './api-gateway-v2'
 import type { ApplicationLoadBalancerAdapter } from './application-load-balancer'
-import type {
-  Request as NodeRequest,
-  Response as NodeResponse,
-} from '@remix-run/node'
 
 import { AWSProxy } from '../server'
 
@@ -21,8 +17,8 @@ import { apiGatewayV2Adapter } from './api-gateway-v2'
 import { applicationLoadBalancerAdapter } from './application-load-balancer'
 
 interface RemixAdapter<T, U> {
-  createRemixRequest: (event: T) => NodeRequest
-  sendRemixResponse: (nodeResponse: NodeResponse) => Promise<U>
+  createRemixRequest: (event: T) => Request
+  sendRemixResponse: (nodeResponse: Response) => Promise<U>
 }
 
 const createRemixAdapter = (awsProxy: AWSProxy): ApiGatewayV1Adapter | ApiGatewayV2Adapter | ApplicationLoadBalancerAdapter => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,6 @@ import type {
 } from 'aws-lambda'
 import type {
   AppLoadContext,
-  Response as NodeResponse,
   ServerBuild,
 } from '@remix-run/node'
 
@@ -59,7 +58,7 @@ export function createRequestHandler({
     const request = awsAdapter.createRemixRequest(event as APIGatewayProxyEvent & APIGatewayProxyEventV2 & ALBEvent)
     const loadContext = getLoadContext?.(event)
 
-    const response = (await handleRequest(request, loadContext)) as NodeResponse
+    const response = (await handleRequest(request, loadContext)) as Response
 
     return awsAdapter.sendRemixResponse(response)
   }


### PR DESCRIPTION
Tweaks required to handle these breaking changes in Remix v2:
- https://remix.run/docs/en/main/start/v2#installglobals
- https://remix.run/docs/en/main/start/v2#removal-of-exported-polyfills

Without these changes, I got this error: https://github.com/remix-run/remix/pull/7779#issuecomment-1783272478