### PR TITLE
fix(api-gateway-v2): remove duplicate cookies for function URLs

### DIFF
--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -45,7 +45,7 @@ function createRemixHeaders(
   }
 
   if (requestCookies) {
-    headers.append('Cookie', requestCookies.join('; '))
+    headers.set('Cookie', requestCookies.join('; '))
   }
 
   return headers


### PR DESCRIPTION
Function URLs get cookies twice, in headers and the `cookies` array, which was causing them to duplicate. This will overwrite rather than duplicate.

Ref: https://github.com/awslabs/aws-lambda-rust-runtime/pull/586

Function URLs use the same apigatewayv2 payload otherwise.