### PR TITLE
Fix getting cookies from headers.

### DIFF
--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -57,11 +57,9 @@ async function sendRemixResponse(
   const cookies: string[] = []
 
   // AWS API Gateway will send back set-cookies outside of response headers.
-  for (const [key, values] of Object.entries(nodeResponse.headers.raw())) {
+  for (const [key, value] of nodeResponse.headers.entries()) {
     if (key.toLowerCase() === 'set-cookie') {
-      for (const value of values) {
-        cookies.push(value)
-      }
+      cookies.push(value)
     }
   }
 


### PR DESCRIPTION
Fixes an issue in the API Gateway v2 adapter where the call to `headers.raw()` throws the following error:

```
TypeError: nodeResponse.headers.raw is not a function
```

As described in remix-run/remix#4354, the `headers.raw()` method is not available in the `Headers` class in Node.js. This change replaces the `headers.raw()` method with [`headers.entries()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries) from the Fetch API to fix the issue.

**Edit:** The original approach used  [`headers.getSetCookie()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie), but @wingleung informed me this is not available in Node 18. The original PR also included dependency updates, which I since removed.